### PR TITLE
Enhance URL Specification

### DIFF
--- a/jf_requests/jf_requests.go
+++ b/jf_requests/jf_requests.go
@@ -53,7 +53,16 @@ func ExecuteRequest(request *http.Request) (map[string]any, error) {
 // When successfull, an auth token wich can be used for further requests is returned.
 func Authorize(baseUrl string, username string, password string) (*AuthResponse, error) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	requestUrl := fmt.Sprintf("%s/Users/AuthenticateByName", baseUrl)
+
+	sanitizedBaseUrl := baseUrl
+	// Strip the leading / from the baseurl, if there is any
+	if string(baseUrl[len(baseUrl)-1]) == "/" {
+		sanitizedBaseUrl = baseUrl[:len(baseUrl)-1]
+	}
+
+	fmt.Println(sanitizedBaseUrl)
+
+	requestUrl := fmt.Sprintf("%s/Users/AuthenticateByName", sanitizedBaseUrl)
 
 	// Create Request Body with Credentials
 	reqbody := &AuthRequestBody{Username: username, Pw: password}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"jf_requests/jf_requests"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -44,6 +45,13 @@ func ParseCLIArgs() *Arguments {
 func CheckArguments(args *Arguments) (bool, string) {
 	if args.BaseUrl == "" {
 		return false, "No URL was given. See -h for more information"
+	}
+
+	// Check if the URL was specified in the correct format.
+	urlpattern := `https?\:\/\/[\d\w._-]+(:\d+)?\/?([/\d\w._-]*?)?$`
+	match, err := regexp.Match(urlpattern, []byte(args.BaseUrl))
+	if !match || err != nil {
+		return false, "URL was supplied in the wrong pattern. The URL must be supplied like so: http(s)://myserver(:123)(/). Instead of the whole hostname, you can also specify the IPv4 address which is pointing to your Jellyfin server."
 	}
 
 	if args.SeriesId == "" && args.Name == "" {

--- a/main.go
+++ b/main.go
@@ -250,7 +250,8 @@ func main() {
 
 	creds, err := jf_requests.Authorize(args.BaseUrl, username, password)
 	if err != nil {
-		color.Red("Authentication Failed! Maybe wrong credentials provided?")
+		color.Red("Authentication Failed!\n")
+		color.Red("%s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This PR enhances the general handling of specified URL and some of the error handling. 
Currently, the error message which is shown when something goes wrong while connecting to a given Jellyfin server only suggests, that the _Authentication Failed_ and that some should _Check the username and password_. Since there are of cause many other reasons, why an initial connection would fail, this PR prints out the whole message returned by the Jellyfin URL library.

Also, a rudimentary check if the passed url conforms a simple pattern is added. Meaning that if the server url is specified in the wrong format, this is catched before trying to reach this server. Also an appropriate error message is displayed.

_Keep in mind that its currently not possible to specify a raw IPv6 address!_