### PR TITLE
Fix Flicker Issue of the Progress Bar on Windows Terminal

### DIFF
--- a/jf_requests/jf_download.go
+++ b/jf_requests/jf_download.go
@@ -28,10 +28,10 @@ func DownloadFromUrl(downloadLink string, name string, outfile string, max int, 
 
 	defer f.Close()
 
-	bar := progressbar.DefaultBytes(
-		resp.ContentLength,
-		fmt.Sprintf("Downloading %d/%d %s: ", current+1, max, name),
-	)
+	bar, _ := progressbar.DefaultBytes(
+		resp.ContentLength, fmt.Sprintf("Downloading %d/%d %s: ", current+1, max, name)),
+		progressbar.OptionUseANSICodes(true)
+
 	io.Copy(io.MultiWriter(f, bar), resp.Body)
 
 	return nil

--- a/jf_requests/jf_download.go
+++ b/jf_requests/jf_download.go
@@ -7,9 +7,30 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/schollz/progressbar/v3"
 )
+
+func CreatePBar(length int64, description string) *progressbar.ProgressBar {
+	desc := ""
+	return progressbar.NewOptions64(
+		length,
+		progressbar.OptionSetDescription(desc),
+		progressbar.OptionSetWriter(os.Stderr),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionSetWidth(10),
+		progressbar.OptionThrottle(65*time.Millisecond),
+		progressbar.OptionShowCount(),
+		progressbar.OptionOnCompletion(func() {
+			fmt.Fprint(os.Stderr, "\n")
+		}),
+		progressbar.OptionSpinnerType(14),
+		progressbar.OptionFullWidth(),
+		progressbar.OptionSetRenderBlankState(true),
+		progressbar.OptionUseANSICodes(true),
+	)
+}
 
 func DownloadFromUrl(downloadLink string, name string, outfile string, max int, current int) error {
 	req, _ := http.NewRequest("GET", downloadLink, nil)
@@ -28,10 +49,7 @@ func DownloadFromUrl(downloadLink string, name string, outfile string, max int, 
 
 	defer f.Close()
 
-	bar, _ := progressbar.DefaultBytes(
-		resp.ContentLength, fmt.Sprintf("Downloading %d/%d %s: ", current+1, max, name)),
-		progressbar.OptionUseANSICodes(true)
-
+	bar := CreatePBar(resp.ContentLength, fmt.Sprintf("downloading %d/%d", current, max))
 	io.Copy(io.MultiWriter(f, bar), resp.Body)
 
 	return nil

--- a/jf_requests/jf_requests.go
+++ b/jf_requests/jf_requests.go
@@ -53,7 +53,16 @@ func ExecuteRequest(request *http.Request) (map[string]any, error) {
 // When successfull, an auth token wich can be used for further requests is returned.
 func Authorize(baseUrl string, username string, password string) (*AuthResponse, error) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	requestUrl := fmt.Sprintf("%s/Users/AuthenticateByName", baseUrl)
+
+	sanitizedBaseUrl := baseUrl
+	// Strip the leading / from the baseurl, if there is any
+	if string(baseUrl[len(baseUrl)-1]) == "/" {
+		sanitizedBaseUrl = baseUrl[:len(baseUrl)-1]
+	}
+
+	fmt.Println(sanitizedBaseUrl)
+
+	requestUrl := fmt.Sprintf("%s/Users/AuthenticateByName", sanitizedBaseUrl)
 
 	// Create Request Body with Credentials
 	reqbody := &AuthRequestBody{Username: username, Pw: password}

--- a/jf_requests/jf_requests.go
+++ b/jf_requests/jf_requests.go
@@ -60,8 +60,6 @@ func Authorize(baseUrl string, username string, password string) (*AuthResponse,
 		sanitizedBaseUrl = baseUrl[:len(baseUrl)-1]
 	}
 
-	fmt.Println(sanitizedBaseUrl)
-
 	requestUrl := fmt.Sprintf("%s/Users/AuthenticateByName", sanitizedBaseUrl)
 
 	// Create Request Body with Credentials

--- a/main.go
+++ b/main.go
@@ -228,6 +228,11 @@ func Download(args *Arguments, auth *jf_requests.AuthResponse) bool {
 			return false
 		}
 
+		if len(items) == 0 {
+			color.Yellow("Did not found anything for the given Searchterm on the Server.")
+			return false
+		}
+
 		item, err := PrintItemSelection(items)
 		if err != nil {
 			color.Red(err.Error())

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"jf_requests/jf_requests"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -44,6 +45,13 @@ func ParseCLIArgs() *Arguments {
 func CheckArguments(args *Arguments) (bool, string) {
 	if args.BaseUrl == "" {
 		return false, "No URL was given. See -h for more information"
+	}
+
+	// Check if the URL was specified in the correct format.
+	urlpattern := `https?\:\/\/[\d\w._-]+(:\d+)?\/?([/\d\w._-]*?)?$`
+	match, err := regexp.Match(urlpattern, []byte(args.BaseUrl))
+	if !match || err != nil {
+		return false, "URL was supplied in the wrong pattern. The URL must be supplied like so: http(s)://myserver(:123)(/). Instead of the whole hostname, you can also specify the IPv4 address which is pointing to your Jellyfin server."
 	}
 
 	if args.SeriesId == "" && args.Name == "" {

--- a/main.go
+++ b/main.go
@@ -250,7 +250,8 @@ func main() {
 
 	creds, err := jf_requests.Authorize(args.BaseUrl, username, password)
 	if err != nil {
-		color.Red("Authentication Failed! Maybe wrong credentials provided?")
+		color.Red("Authentication Failed!\n")
+		color.Red("%s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
On Windows terminal, the handling of the progressbar Rendering is a bit different. Because of this, we need to tell the progressbar to use special ansi codes to clear out the line, where the progressbar resided. 

Also this PR will fix some smaller issues I found. 