### PR TITLE
Fix Progress Bar Flickering on Windows Terminal

### DIFF
--- a/jf_requests/jf_download.go
+++ b/jf_requests/jf_download.go
@@ -28,10 +28,10 @@ func DownloadFromUrl(downloadLink string, name string, outfile string, max int, 
 
 	defer f.Close()
 
-	bar := progressbar.DefaultBytes(
-		resp.ContentLength,
-		fmt.Sprintf("Downloading %d/%d %s: ", current+1, max, name),
-	)
+	bar, _ := progressbar.DefaultBytes(
+		resp.ContentLength, fmt.Sprintf("Downloading %d/%d %s: ", current+1, max, name)),
+		progressbar.OptionUseANSICodes(true)
+
 	io.Copy(io.MultiWriter(f, bar), resp.Body)
 
 	return nil

--- a/jf_requests/jf_download.go
+++ b/jf_requests/jf_download.go
@@ -7,9 +7,30 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/schollz/progressbar/v3"
 )
+
+func CreatePBar(length int64, description string) *progressbar.ProgressBar {
+	desc := ""
+	return progressbar.NewOptions64(
+		length,
+		progressbar.OptionSetDescription(desc),
+		progressbar.OptionSetWriter(os.Stderr),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionSetWidth(10),
+		progressbar.OptionThrottle(65*time.Millisecond),
+		progressbar.OptionShowCount(),
+		progressbar.OptionOnCompletion(func() {
+			fmt.Fprint(os.Stderr, "\n")
+		}),
+		progressbar.OptionSpinnerType(14),
+		progressbar.OptionFullWidth(),
+		progressbar.OptionSetRenderBlankState(true),
+		progressbar.OptionUseANSICodes(true),
+	)
+}
 
 func DownloadFromUrl(downloadLink string, name string, outfile string, max int, current int) error {
 	req, _ := http.NewRequest("GET", downloadLink, nil)
@@ -28,10 +49,7 @@ func DownloadFromUrl(downloadLink string, name string, outfile string, max int, 
 
 	defer f.Close()
 
-	bar, _ := progressbar.DefaultBytes(
-		resp.ContentLength, fmt.Sprintf("Downloading %d/%d %s: ", current+1, max, name)),
-		progressbar.OptionUseANSICodes(true)
-
+	bar := CreatePBar(resp.ContentLength, fmt.Sprintf("downloading %d/%d", current, max))
 	io.Copy(io.MultiWriter(f, bar), resp.Body)
 
 	return nil

--- a/jf_requests/jf_requests.go
+++ b/jf_requests/jf_requests.go
@@ -60,8 +60,6 @@ func Authorize(baseUrl string, username string, password string) (*AuthResponse,
 		sanitizedBaseUrl = baseUrl[:len(baseUrl)-1]
 	}
 
-	fmt.Println(sanitizedBaseUrl)
-
 	requestUrl := fmt.Sprintf("%s/Users/AuthenticateByName", sanitizedBaseUrl)
 
 	// Create Request Body with Credentials

--- a/main.go
+++ b/main.go
@@ -228,6 +228,11 @@ func Download(args *Arguments, auth *jf_requests.AuthResponse) bool {
 			return false
 		}
 
+		if len(items) == 0 {
+			color.Yellow("Did not found anything for the given Searchterm on the Server.")
+			return false
+		}
+
 		item, err := PrintItemSelection(items)
 		if err != nil {
 			color.Red(err.Error())


### PR DESCRIPTION
This PR fixes an issue with the progress bar in conjunction with the Windows Terminal application. Also, this PR fixes a Bug with the selection, where the select menu was shown even if they weren't anything to download. 