### PR TITLE
:art: Reduce progress bar refresh interval

### DIFF
--- a/jf_requests/jf_download.go
+++ b/jf_requests/jf_download.go
@@ -19,7 +19,7 @@ func CreatePBar(length int64, description string) *progressbar.ProgressBar {
 		progressbar.OptionSetWriter(os.Stderr),
 		progressbar.OptionShowBytes(true),
 		progressbar.OptionSetWidth(10),
-		progressbar.OptionThrottle(65*time.Millisecond),
+		progressbar.OptionThrottle(1*time.Second),
 		progressbar.OptionShowCount(),
 		progressbar.OptionOnCompletion(func() {
 			fmt.Fprint(os.Stderr, "\n")


### PR DESCRIPTION
The progress bar still flickers in some instance. Also, if the terminal window is to small, a massive amount of newlines will be printed as the progress bar will print a new line for each refresh cycle. 

This pr reduces the refresh cycle to 1 second so that the progress bar will not spam the terminal if the terminal is not big enough. 