### PR TITLE
:arrow_up: Use Go version 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module jf_requests
 
-go 1.18
+go 1.23
 
 require (
 	github.com/fatih/color v1.15.0 // indirect


### PR DESCRIPTION
Use Go Version 1.23. 
_Note that this makes it necessary to use an external ppa if you are using ubuntu 22.04 lts, as ubuntu only ships with go release 1.18 by default._