### PR TITLE
Do not show Selection if only a Single Entity is available

### DIFF
--- a/jf_requests/jf_episodes.go
+++ b/jf_requests/jf_episodes.go
@@ -98,7 +98,7 @@ func (series *Series) GetSeasonForId(seasonId string) (*Season, error) {
 }
 
 func (series *Series) PrintAndGetSelection() ([]Season, error) {
-	fmt.Println("Which Seasons do you want to download:")
+	fmt.Println("Which Season do you want to download:")
 
 	color.Cyan("  0. All")
 	for idx, season := range series.Seasons {

--- a/main.go
+++ b/main.go
@@ -136,6 +136,7 @@ func DownloadSeries(auth *jf_requests.AuthResponse, baseurl string, item *jf_req
 		return false
 	}
 
+	color.Green("Series: %s\n", item.Name)
 	var selected_seasons []jf_requests.Season
 	if seasonId != "" {
 		if selected_season, geterr := series.GetSeasonForId(seasonId); geterr == nil {

--- a/main.go
+++ b/main.go
@@ -201,15 +201,18 @@ func Download(args *Arguments, auth *jf_requests.AuthResponse) bool {
 			return false
 		}
 
+		var item *jf_requests.Item
 		if len(items) == 0 {
 			color.Yellow("Did not found anything for the given Searchterm on the Server.")
 			return false
-		}
-
-		item, err := PrintItemSelection(items)
-		if err != nil {
-			color.Red(err.Error())
-			return false
+		} else if len(items) == 1 {
+			item = &items[0]
+		} else {
+			item, err = PrintItemSelection(items)
+			if err != nil {
+				color.Red(err.Error())
+				return false
+			}
 		}
 
 		if item.Type == "Series" {


### PR DESCRIPTION
Currently, the selection prompt for a result using a searchterm is always displayed, even if there is only a single entity to select. This PR makes it that the prompt is only displayed, if there are two or more results which you can choose from. 