### PR TITLE
Fix Windows Newlines

### DIFF
--- a/jf_requests/cli_helpers.go
+++ b/jf_requests/cli_helpers.go
@@ -23,7 +23,8 @@ func GetUserChoice(number_of_choices int) (int, error) {
 	fmt.Print("==> ")
 	reader := bufio.NewReader(os.Stdin)
 	response, _ := reader.ReadString('\n')
-	response = strings.Split(response, "\n")[0]
+	unified_response_string := strings.Replace(response, "\r\n", "\n", -1)
+	response = strings.Split(unified_response_string, "\n")[0]
 	if selection, err := strconv.Atoi(response); err == nil {
 		if selection < 0 || selection > number_of_choices {
 			return -1, errors.New("Invalid Selection")

--- a/jf_requests/cli_helpers.go
+++ b/jf_requests/cli_helpers.go
@@ -27,12 +27,12 @@ func GetUserChoice(number_of_choices int) (int, error) {
 	response = strings.Split(unified_response_string, "\n")[0]
 	if selection, err := strconv.Atoi(response); err == nil {
 		if selection < 0 || selection > number_of_choices {
-			return -1, errors.New("Invalid Selection")
+			return -1, errors.New("invalid selection")
 		}
 
 		return selection, nil
 	} else {
 		slog.Error(err.Error())
-		return -1, errors.New("Only provide a single number")
+		return -1, errors.New("only provide a single number")
 	}
 }

--- a/jf_requests/cli_helpers.go
+++ b/jf_requests/cli_helpers.go
@@ -23,7 +23,7 @@ func GetUserChoice(number_of_choices int) (int, error) {
 	fmt.Print("==> ")
 	reader := bufio.NewReader(os.Stdin)
 	response, _ := reader.ReadString('\n')
-	unified_response_string := strings.Replace(response, "\r\n", "\n", -1)
+	unified_response_string := strings.Replace(response, "\r\n", "", -1)
 	response = strings.Split(unified_response_string, "\n")[0]
 	if selection, err := strconv.Atoi(response); err == nil {
 		if selection < 0 || selection > number_of_choices {


### PR DESCRIPTION
It seems that on windows, the `\r` - Character is still included in a selection string, if a user presses the enter key. This pr unifies the strings so that the carriage return character on a newline is removed. 

fixes #25 