### PR TITLE
:art:  Add a flag to keep original filenames for series episodes

### DIFF
--- a/jf_requests/jf_movies.go
+++ b/jf_requests/jf_movies.go
@@ -3,6 +3,7 @@ package jf_requests
 import (
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/fatih/color"
@@ -12,6 +13,7 @@ type Movie struct {
 	Name         string
 	Id           string
 	Container    string
+	Path         string
 	CanDownload  bool
 	DownloadLink string
 }
@@ -35,6 +37,7 @@ func GetMovieFromItem(auth *AuthResponse, baseurl string, item *Item) (*Movie, e
 		Id:           res["Id"].(string),
 		Container:    res["Container"].(string),
 		CanDownload:  res["CanDownload"].(bool),
+		Path:         res["Path"].(string),
 		DownloadLink: ""}
 
 	mov.DownloadLink = GetDownloadLinkForId(baseurl, auth.Token, mov.Id)
@@ -54,8 +57,15 @@ func (movie *Movie) PrintAndGetConfirmation() bool {
 	}
 }
 
-func (movie *Movie) Download() {
-	suffix := strings.Split(movie.Container, ",")[0]
-	outfilename := fmt.Sprintf("%s_%s.%s", movie.Name, movie.Name, suffix)
+func (movie *Movie) Download(keepFilename bool) {
+	var outfilename string
+	if keepFilename {
+		basename := path.Base(movie.Path)
+		outfilename = basename
+	} else {
+		suffix := strings.Split(movie.Container, ",")[0]
+		outfilename = fmt.Sprintf("%s_%s.%s", movie.Name, movie.Name, suffix)
+	}
+
 	DownloadFromUrl(movie.DownloadLink, movie.Name, outfilename, 1, 0)
 }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/term"
 )
 
-const VERSION string = "v1.3.2-prerelease-01"
+const VERSION string = "v1.4.0"
 
 type Arguments struct {
 	BaseUrl       string
@@ -167,7 +167,7 @@ func DownloadSeries(auth *jf_requests.AuthResponse, baseurl string, item *jf_req
 	return true
 }
 
-func DownloadMovie(auth *jf_requests.AuthResponse, baseurl string, item *jf_requests.Item) bool {
+func DownloadMovie(auth *jf_requests.AuthResponse, baseurl string, item *jf_requests.Item, keepFilename bool) bool {
 	movie, err := jf_requests.GetMovieFromItem(auth, baseurl, item)
 	if err != nil {
 		color.Red("Failed to obtain Movie for given id: %s", err)
@@ -175,7 +175,7 @@ func DownloadMovie(auth *jf_requests.AuthResponse, baseurl string, item *jf_requ
 	}
 
 	if movie.PrintAndGetConfirmation() {
-		movie.Download()
+		movie.Download(keepFilename)
 	} else {
 		return false
 	}
@@ -194,7 +194,7 @@ func Download(args *Arguments, auth *jf_requests.AuthResponse) bool {
 		if item.Type == "Series" {
 			return DownloadSeries(auth, args.BaseUrl, item, args.SeasonId, args.KeepFilenames)
 		} else {
-			return DownloadMovie(auth, args.BaseUrl, item)
+			return DownloadMovie(auth, args.BaseUrl, item, args.KeepFilenames)
 		}
 
 	} else if args.Name != "" {
@@ -221,7 +221,7 @@ func Download(args *Arguments, auth *jf_requests.AuthResponse) bool {
 		if item.Type == "Series" {
 			return DownloadSeries(auth, args.BaseUrl, item, args.SeasonId, args.KeepFilenames)
 		} else {
-			return DownloadMovie(auth, args.BaseUrl, item)
+			return DownloadMovie(auth, args.BaseUrl, item, args.KeepFilenames)
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/term"
 )
 
-const VERSION string = "v1.4.0"
+const VERSION string = "v1.4.0-prerelease-1"
 
 type Arguments struct {
 	BaseUrl       string


### PR DESCRIPTION
With this PR, a `-keepFilename` - Flag is added. If this is set, the filenames of downloaded series episodes will stay the same as the files on the server. 

Closes #32 