### PR TITLE
⚡️ Move the item search to the server

### DIFF
--- a/jf_requests/jf_items.go
+++ b/jf_requests/jf_items.go
@@ -3,6 +3,7 @@ package jf_requests
 import (
 	"errors"
 	"fmt"
+	"net/url"
 )
 
 type Item struct {
@@ -80,7 +81,8 @@ func GetAllItems(auth *AuthResponse, baseurl string) ([]Item, error) {
 
 // Returns the item whose name includes the given search term.
 func SearchItemsForText(auth *AuthResponse, baseurl string, searchtext string) ([]Item, error) {
-	requestUrl := baseurl + fmt.Sprintf("/Users/%s/Items/?recursive=true&limit=10&searchTerm=%s&includeItemTypes=Movie&includeItemTypes=Series&includeItemTypes=Folder", auth.UserId, searchtext)
+	escapedSearchterm := url.QueryEscape(searchtext)
+	requestUrl := baseurl + fmt.Sprintf("/Users/%s/Items/?recursive=true&limit=10&searchTerm=%s&includeItemTypes=Movie&includeItemTypes=Series&includeItemTypes=Folder", auth.UserId, escapedSearchterm)
 
 	res, err := MakeRequest(auth.Token, requestUrl, "GET", nil)
 	if err != nil {

--- a/jf_requests/jf_items.go
+++ b/jf_requests/jf_items.go
@@ -82,7 +82,7 @@ func GetAllItems(auth *AuthResponse, baseurl string) ([]Item, error) {
 }
 
 // Returns the item whose name includes the given search term.
-func GetItemsForText(auth *AuthResponse, baseUrl string, searchtext string) ([]Item, error) {
+func SearchItemsForText(auth *AuthResponse, baseUrl string, searchtext string) ([]Item, error) {
 	all, err := GetAllItems(auth, baseUrl)
 	if err != nil {
 		return nil, err

--- a/jf_requests/jf_items.go
+++ b/jf_requests/jf_items.go
@@ -3,7 +3,6 @@ package jf_requests
 import (
 	"errors"
 	"fmt"
-	"strings"
 )
 
 type Item struct {
@@ -18,7 +17,6 @@ func GetItem(rawItems []any, parentItem *Item) []Item {
 		itm := Item{
 			Name: item.(map[string]any)["Name"].(string),
 			Id:   item.(map[string]any)["Id"].(string),
-			Type: item.(map[string]any)["Id"].(string),
 		}
 
 		if itmtype, ok := item.(map[string]any)["Type"].(string); ok {
@@ -78,24 +76,21 @@ func GetAllItems(auth *AuthResponse, baseurl string) ([]Item, error) {
 	}
 
 	return items, nil
-
 }
 
 // Returns the item whose name includes the given search term.
-func SearchItemsForText(auth *AuthResponse, baseUrl string, searchtext string) ([]Item, error) {
-	all, err := GetAllItems(auth, baseUrl)
+func SearchItemsForText(auth *AuthResponse, baseurl string, searchtext string) ([]Item, error) {
+	requestUrl := baseurl + fmt.Sprintf("/Users/%s/Items/?recursive=true&limit=10&searchTerm=%s&includeItemTypes=Movie&includeItemTypes=Series&includeItemTypes=Folder", auth.UserId, searchtext)
+
+	res, err := MakeRequest(auth.Token, requestUrl, "GET", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var results []Item
-	for _, item := range all {
-		if strings.Contains(strings.ToLower(item.Name), strings.ToLower(searchtext)) {
-			results = append(results, item)
-		}
-	}
+	itemsRaw := res["Items"].([]any)
+	items := GetItem(itemsRaw, nil)
 
-	return results, nil
+	return items, nil
 }
 
 func GetItemForId(auth *AuthResponse, baseurl string, id string) (*Item, error) {

--- a/main.go
+++ b/main.go
@@ -219,7 +219,7 @@ func Download(args *Arguments, auth *jf_requests.AuthResponse) bool {
 		}
 
 	} else if args.Name != "" {
-		items, err := jf_requests.GetItemsForText(auth, args.BaseUrl, args.Name)
+		items, err := jf_requests.SearchItemsForText(auth, args.BaseUrl, args.Name)
 		if err != nil {
 			color.Red("Failed to obtain Episode Information for given id: %s", err)
 			return false


### PR DESCRIPTION
Currently, before the items are filtered for the item name, the whole content list is downloaded. After this, the results are parsed and filtered. This is a massive overhead when there is only one entity which should be downloaded. 

In this PR, the item filtering is handled by the server itself which then only will return the results of a queried searchterm. It should increase the performance and memory footprint of the client as the entities will be prefiltered.