### PR TITLE
feat: Add ability to DL movies from a provided collection id

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ type Arguments struct {
 	Password      string
 	SeriesId      string
 	SeasonId      string
+	CollectionId  string
 	Name          string
 	KeepFilenames bool
 	Version       bool
@@ -39,6 +40,7 @@ func ParseCLIArgs() *Arguments {
 	flag.StringVar(&args.BaseUrl, "url", "", "Base URL which points to the Jellyfin Instance")
 	flag.StringVar(&args.SeriesId, "seriesid", "", "ID which points to the series which should be downloaded")
 	flag.StringVar(&args.SeasonId, "seasonid", "", "If given, only the episodes with the provided season Id will be downloaded")
+	flag.StringVar(&args.CollectionId, "collectionid", "", "ID which points to the collection which should be downloaded. (movies only)")
 	flag.StringVar(&args.Username, "username", "", "Username used to login to the Jellyfin instance. If not provided, password will be prompted.")
 	flag.StringVar(&args.Password, "password", "", "Passwort for the Jellyfin instance. If not provided, username will be prompted.")
 	flag.StringVar(&args.Name, "name", "", "Name of the Show or Movie you want to download.")
@@ -67,8 +69,8 @@ func CheckArguments(args *Arguments) (bool, string) {
 	// Remove a leading / if it was provided
 	args.BaseUrl = strings.TrimSuffix(args.BaseUrl, "/")
 
-	if args.SeriesId == "" && args.Name == "" {
-		return false, "No SeriesID or Name was given. See -h for more information."
+	if args.SeriesId == "" && args.Name == "" && args.CollectionId == "" {
+		return false, "No SeriesID, CollectionID, or Name was given. See -h for more information."
 	}
 
 	return true, ""
@@ -183,8 +185,52 @@ func DownloadMovie(auth *jf_requests.AuthResponse, baseurl string, item *jf_requ
 	return true
 }
 
+func DownloadCollection(auth *jf_requests.AuthResponse, baseurl string, collection *jf_requests.Item, keepFilename bool) bool {
+	items, err := jf_requests.GetItemsForParentId(auth, baseurl, collection)
+	if err != nil {
+		color.Red("Failed to get items: %s", err)
+		return false
+	}
+
+	color.Cyan("Downloading these Movies from the %s:", collection.Name)
+	for _, item := range items {
+		if item.Type == "Movie" {
+			color.Cyan("%s", item.Name)
+		}
+	}
+
+	if !GetConfirmation() {
+		return false
+	}
+
+	for _, item := range items {
+		if item.Type == "Movie" {
+			movie, err := jf_requests.GetMovieFromItem(auth, baseurl, &item)
+			if err != nil {
+				color.Red("Failed to obtain Movie for given id: %s", err)
+				return false
+			}
+
+			movie.Download(keepFilename)
+		} else {
+			color.Yellow("Skipping %s: Item type '%s' is not supported in collections yet.", item.Name, item.Type)
+		}
+	}
+
+	return true
+}
+
 func Download(args *Arguments, auth *jf_requests.AuthResponse) bool {
-	if args.SeriesId != "" {
+	if args.CollectionId != "" {
+		collection, err := jf_requests.GetItemForId(auth, args.BaseUrl, args.CollectionId)
+		if err != nil {
+			color.Red("Failed to find provided collection: %s", err)
+			return false
+		}
+
+		return DownloadCollection(auth, args.BaseUrl, collection, args.KeepFilenames)
+
+	} else if args.SeriesId != "" {
 		item, err := jf_requests.GetItemForId(auth, args.BaseUrl, args.SeriesId)
 		if err != nil {
 			color.Red("Failed to obtain items for given id: %s", err)


### PR DESCRIPTION
This is really just the start of a larger feature to allow downloading a Collection by a provided ID. I believe it is possible to have individual TV episodes, series, etc., within a collection. My working use-cases are currently just for Movies within a collection, which is what I have implemented with messages indicating other item types will not be downloaded.